### PR TITLE
Fnalibs patch and iOS/tvOS fixup

### DIFF
--- a/licenses/LICENSE
+++ b/licenses/LICENSE
@@ -1,6 +1,6 @@
 Microsoft Public License (Ms-PL)
-FNA - Copyright 2009-2021 Ethan Lee and the MonoGame Team
-FNA.NET - Copyright 2021 ryancheung
+FNA - Copyright 2009-2022 Ethan Lee and the MonoGame Team
+FNA.NET - Copyright 2022 ryancheung
 
 All rights reserved.
 

--- a/nuget/FNA.NET.nuspec
+++ b/nuget/FNA.NET.nuspec
@@ -21,7 +21,11 @@
       </group>
       <group targetFramework="net6.0-windows7.0">
       </group>
-      <group targetFramework="net6.0-ios15.0">
+      <group targetFramework="net6.0-ios15.4">
+        <dependency id="FNA.NET.MoltenVK" version="1.0.0.5" />
+      </group>
+      <group targetFramework="net6.0-tvos15.4">
+        <dependency id="FNA.NET.MoltenVK" version="1.0.0.5" />
       </group>
       <group targetFramework="net6.0-android31.0">
         <dependency id="SDL2DroidSharp-JBindings" version="1.0.1" />
@@ -42,13 +46,13 @@
     <file src="..\Artifacts\Release\net6.0-windows\FNA.NET.dll" target="lib/net6.0-windows7.0" />
     <file src="..\Artifacts\Release\net6.0-windows\FNA.NET.pdb" target="lib/net6.0-windows7.0" />
 
-    <file src="..\Artifacts\Release\net6.0-ios\FNA.NET.dll" target="lib/net6.0-ios15.0" />
-    <file src="..\Artifacts\Release\net6.0-ios\FNA.NET.pdb" target="lib/net6.0-ios15.0" />
-    <file src="manifests\manifest_ios" target="lib/net6.0-ios15.0/FNA.NET.resources/manifest" />
+    <file src="..\Artifacts\Release\net6.0-ios\FNA.NET.dll" target="lib/net6.0-ios15.4" />
+    <file src="..\Artifacts\Release\net6.0-ios\FNA.NET.pdb" target="lib/net6.0-ios15.4" />
+    <file src="manifests\manifest_ios" target="lib/net6.0-ios15.4/FNA.NET.resources/manifest" />
 
-    <file src="..\Artifacts\Release\net6.0-tvos\FNA.NET.dll" target="lib/net6.0-tvos15.0" />
-    <file src="..\Artifacts\Release\net6.0-tvos\FNA.NET.pdb" target="lib/net6.0-tvos15.0" />
-    <file src="manifests\manifest_tvos" target="lib/net6.0-tvos15.0/FNA.NET.resources/manifest" />
+    <file src="..\Artifacts\Release\net6.0-tvos\FNA.NET.dll" target="lib/net6.0-tvos15.4" />
+    <file src="..\Artifacts\Release\net6.0-tvos\FNA.NET.pdb" target="lib/net6.0-tvos15.4" />
+    <file src="manifests\manifest_tvos" target="lib/net6.0-tvos15.4/FNA.NET.resources/manifest" />
 
     <file src="..\Artifacts\Release\net6.0-ios\FNA.NET.resources\**\*.*" target="content/res" />
 

--- a/samples/iOSGame1/Program.cs
+++ b/samples/iOSGame1/Program.cs
@@ -24,7 +24,7 @@ namespace iOSGame1
             // Enable high DPI "Retina" support. Trust us, you'll want this.
             Environment.SetEnvironmentVariable("FNA_GRAPHICS_ENABLE_HIGHDPI", "1");
 
-            SDL.SDL_SetHint("FNA3D_FORCE_DRIVER", "Metal");
+            SDL.SDL_SetHint("FNA3D_FORCE_DRIVER", "Vulkan");
 
             // Keep mouse and touch input separate.
             SDL.SDL_SetHint(SDL.SDL_HINT_MOUSE_TOUCH_EVENTS, "0");

--- a/samples/tvOSGame1/Program.cs
+++ b/samples/tvOSGame1/Program.cs
@@ -24,7 +24,7 @@ namespace tvOSGame1
             // Enable high DPI "Retina" support. Trust us, you'll want this.
             Environment.SetEnvironmentVariable("FNA_GRAPHICS_ENABLE_HIGHDPI", "1");
 
-            SDL.SDL_SetHint("FNA3D_FORCE_DRIVER", "Metal");
+            SDL.SDL_SetHint("FNA3D_FORCE_DRIVER", "Vulkan");
 
             // Keep mouse and touch input separate.
             SDL.SDL_SetHint(SDL.SDL_HINT_MOUSE_TOUCH_EVENTS, "0");

--- a/src/Audio/AudioCategory.cs
+++ b/src/Audio/AudioCategory.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Audio/AudioChannels.cs
+++ b/src/Audio/AudioChannels.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Audio/AudioEmitter.cs
+++ b/src/Audio/AudioEmitter.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Audio/AudioEngine.cs
+++ b/src/Audio/AudioEngine.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Audio/AudioEngine.cs
+++ b/src/Audio/AudioEngine.cs
@@ -206,6 +206,22 @@ namespace Microsoft.Xna.Framework.Audio
 
 			// All XACT references have to go through here...
 			notificationDesc = new FAudio.FACTNotificationDescription();
+			notificationDesc.flags = FAudio.FACT_FLAG_NOTIFICATION_PERSIST;
+			notificationDesc.type = FAudio.FACTNOTIFICATIONTYPE_WAVEBANKDESTROYED;
+			FAudio.FACTAudioEngine_RegisterNotification(
+				handle,
+				ref notificationDesc
+			);
+			notificationDesc.type = FAudio.FACTNOTIFICATIONTYPE_SOUNDBANKDESTROYED;
+			FAudio.FACTAudioEngine_RegisterNotification(
+				handle,
+				ref notificationDesc
+			);
+			notificationDesc.type = FAudio.FACTNOTIFICATIONTYPE_CUEDESTROYED;
+			FAudio.FACTAudioEngine_RegisterNotification(
+				handle,
+				ref notificationDesc
+			);
 		}
 
 		#endregion
@@ -340,105 +356,13 @@ namespace Microsoft.Xna.Framework.Audio
 
 		#region Internal Methods
 
-		internal void RegisterWaveBank(
+		internal void RegisterPointer(
 			IntPtr ptr,
 			WeakReference reference
 		) {
-			notificationDesc.type = FAudio.FACTNOTIFICATIONTYPE_WAVEBANKDESTROYED;
-			notificationDesc.pWaveBank = ptr;
-			FAudio.FACTAudioEngine_RegisterNotification(
-				handle,
-				ref notificationDesc
-			);
 			lock (xactPtrs)
 			{
-				xactPtrs.Add(ptr, reference);
-			}
-		}
-
-		internal void RegisterSoundBank(
-			IntPtr ptr,
-			WeakReference reference
-		) {
-			notificationDesc.type = FAudio.FACTNOTIFICATIONTYPE_SOUNDBANKDESTROYED;
-			notificationDesc.pSoundBank = ptr;
-			FAudio.FACTAudioEngine_RegisterNotification(
-				handle,
-				ref notificationDesc
-			);
-			lock (xactPtrs)
-			{
-				xactPtrs.Add(ptr, reference);
-			}
-		}
-
-		internal void RegisterCue(
-			IntPtr ptr,
-			WeakReference reference
-		) {
-			notificationDesc.type = FAudio.FACTNOTIFICATIONTYPE_CUEDESTROYED;
-			notificationDesc.pCue = ptr;
-			FAudio.FACTAudioEngine_RegisterNotification(
-				handle,
-				ref notificationDesc
-			);
-			lock (xactPtrs)
-			{
-				xactPtrs.Add(ptr, reference);
-			}
-		}
-
-		internal void UnregisterWaveBank(IntPtr ptr)
-		{
-			lock (xactPtrs)
-			{
-				if (!xactPtrs.ContainsKey(ptr))
-				{
-					return;
-				}
-				notificationDesc.type = FAudio.FACTNOTIFICATIONTYPE_WAVEBANKDESTROYED;
-				notificationDesc.pWaveBank = ptr;
-				FAudio.FACTAudioEngine_UnRegisterNotification(
-					handle,
-					ref notificationDesc
-				);
-				xactPtrs.Remove(ptr);
-			}
-		}
-
-		internal void UnregisterSoundBank(IntPtr ptr)
-		{
-			lock (xactPtrs)
-			{
-				if (!xactPtrs.ContainsKey(ptr))
-				{
-					return;
-				}
-				notificationDesc.type = FAudio.FACTNOTIFICATIONTYPE_SOUNDBANKDESTROYED;
-				notificationDesc.pSoundBank = ptr;
-				FAudio.FACTAudioEngine_UnRegisterNotification(
-					handle,
-					ref notificationDesc
-				);
-				xactPtrs.Remove(ptr);
-			}
-		}
-
-		internal void UnregisterCue(IntPtr ptr)
-		{
-			lock (xactPtrs)
-			{
-				if (!xactPtrs.ContainsKey(ptr))
-				{
-					return;
-				}
-				notificationDesc.type = FAudio.FACTNOTIFICATIONTYPE_CUEDESTROYED;
-				notificationDesc.pCue = ptr;
-				FAudio.FACTAudioEngine_UnRegisterNotification(
-					handle,
-					ref notificationDesc
-				);
-				xactPtrs.Remove(ptr);
+				xactPtrs[ptr] = reference;
 			}
 		}
 

--- a/src/Audio/AudioListener.cs
+++ b/src/Audio/AudioListener.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Audio/AudioStopOptions.cs
+++ b/src/Audio/AudioStopOptions.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Audio/Cue.cs
+++ b/src/Audio/Cue.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Audio/Cue.cs
+++ b/src/Audio/Cue.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Xna.Framework.Audio
 			bank = soundBank;
 
 			selfReference = new WeakReference(this, true);
-			bank.engine.RegisterCue(handle, selfReference);
+			bank.engine.RegisterPointer(handle, selfReference);
 		}
 
 		#endregion
@@ -293,7 +293,6 @@ namespace Microsoft.Xna.Framework.Audio
 					// If this is Disposed, stop leaking memory!
 					if (!bank.engine.IsDisposed)
 					{
-						bank.engine.UnregisterCue(handle);
 						FAudio.FACTCue_Destroy(handle);
 					}
 					OnCueDestroyed();

--- a/src/Audio/DynamicSoundEffectInstance.cs
+++ b/src/Audio/DynamicSoundEffectInstance.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Audio/DynamicSoundEffectInstance.cs
+++ b/src/Audio/DynamicSoundEffectInstance.cs
@@ -136,7 +136,10 @@ namespace Microsoft.Xna.Framework.Audio
 			base.Play();
 			lock (FrameworkDispatcher.Streams)
 			{
-				FrameworkDispatcher.Streams.Add(this);
+				if (!FrameworkDispatcher.Streams.Contains(this))
+				{
+					FrameworkDispatcher.Streams.Add(this);
+				}
 			}
 		}
 

--- a/src/Audio/InstancePlayLimitException.cs
+++ b/src/Audio/InstancePlayLimitException.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Audio/Microphone.cs
+++ b/src/Audio/Microphone.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Audio/MicrophoneState.cs
+++ b/src/Audio/MicrophoneState.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Audio/NoAudioHardwareException.cs
+++ b/src/Audio/NoAudioHardwareException.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Audio/NoMicrophoneConnectedException.cs
+++ b/src/Audio/NoMicrophoneConnectedException.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Audio/RendererDetail.cs
+++ b/src/Audio/RendererDetail.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Audio/SoundBank.cs
+++ b/src/Audio/SoundBank.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Audio/SoundBank.cs
+++ b/src/Audio/SoundBank.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Xna.Framework.Audio
 				(int) dspSettings.SrcChannelCount *
 				(int) dspSettings.DstChannelCount
 			);
-			engine.RegisterSoundBank(handle, selfReference);
+			engine.RegisterPointer(handle, selfReference);
 			IsDisposed = false;
 		}
 
@@ -146,9 +146,7 @@ namespace Microsoft.Xna.Framework.Audio
 					// If this is disposed, stop leaking memory!
 					if (!engine.IsDisposed)
 					{
-						engine.UnregisterSoundBank(handle);
 						FAudio.FACTSoundBank_Destroy(handle);
-						Marshal.FreeHGlobal(dspSettings.pMatrixCoefficients);
 					}
 					OnSoundBankDestroyed();
 				}
@@ -274,6 +272,11 @@ namespace Microsoft.Xna.Framework.Audio
 			IsDisposed = true;
 			handle = IntPtr.Zero;
 			selfReference = null;
+			if (dspSettings.pMatrixCoefficients != IntPtr.Zero)
+			{
+				Marshal.FreeHGlobal(dspSettings.pMatrixCoefficients);
+				dspSettings.pMatrixCoefficients = IntPtr.Zero;
+			}
 		}
 
 		#endregion

--- a/src/Audio/SoundEffect.cs
+++ b/src/Audio/SoundEffect.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Audio/SoundEffectInstance.cs
+++ b/src/Audio/SoundEffectInstance.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Audio/SoundState.cs
+++ b/src/Audio/SoundState.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Audio/WaveBank.cs
+++ b/src/Audio/WaveBank.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Audio/WaveBank.cs
+++ b/src/Audio/WaveBank.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Xna.Framework.Audio
 
 			engine = audioEngine;
 			selfReference = new WeakReference(this, true);
-			engine.RegisterWaveBank(handle, selfReference);
+			engine.RegisterPointer(handle, selfReference);
 			IsDisposed = false;
 		}
 
@@ -138,7 +138,7 @@ namespace Microsoft.Xna.Framework.Audio
 
 			engine = audioEngine;
 			selfReference = new WeakReference(this, true);
-			engine.RegisterWaveBank(handle, selfReference);
+			engine.RegisterPointer(handle, selfReference);
 			IsDisposed = false;
 		}
 
@@ -190,7 +190,6 @@ namespace Microsoft.Xna.Framework.Audio
 					// If this is disposed, stop leaking memory!
 					if (!engine.IsDisposed)
 					{
-						engine.UnregisterWaveBank(handle);
 						FAudio.FACTWaveBank_Destroy(handle);
 					}
 					OnWaveBankDestroyed();

--- a/src/BoundingBox.cs
+++ b/src/BoundingBox.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/BoundingFrustum.cs
+++ b/src/BoundingFrustum.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/BoundingSphere.cs
+++ b/src/BoundingSphere.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Color.cs
+++ b/src/Color.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/ContainmentType.cs
+++ b/src/ContainmentType.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentExtensions.cs
+++ b/src/Content/ContentExtensions.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentLoadException.cs
+++ b/src/Content/ContentLoadException.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentManager.cs
+++ b/src/Content/ContentManager.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReader.cs
+++ b/src/Content/ContentReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/AlphaTestEffectReader.cs
+++ b/src/Content/ContentReaders/AlphaTestEffectReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/ArrayReader.cs
+++ b/src/Content/ContentReaders/ArrayReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/BasicEffectReader.cs
+++ b/src/Content/ContentReaders/BasicEffectReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/BooleanReader.cs
+++ b/src/Content/ContentReaders/BooleanReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/BoundingBoxReader.cs
+++ b/src/Content/ContentReaders/BoundingBoxReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/BoundingFrustumReader.cs
+++ b/src/Content/ContentReaders/BoundingFrustumReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/BoundingSphereReader.cs
+++ b/src/Content/ContentReaders/BoundingSphereReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/ByteReader.cs
+++ b/src/Content/ContentReaders/ByteReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/CharReader.cs
+++ b/src/Content/ContentReaders/CharReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/ColorReader.cs
+++ b/src/Content/ContentReaders/ColorReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/CurveReader.cs
+++ b/src/Content/ContentReaders/CurveReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/DateTimeReader.cs
+++ b/src/Content/ContentReaders/DateTimeReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/DecimalReader.cs
+++ b/src/Content/ContentReaders/DecimalReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/DictionaryReader.cs
+++ b/src/Content/ContentReaders/DictionaryReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/DoubleReader.cs
+++ b/src/Content/ContentReaders/DoubleReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/DualTextureEffectReader.cs
+++ b/src/Content/ContentReaders/DualTextureEffectReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/EffectMaterialReader.cs
+++ b/src/Content/ContentReaders/EffectMaterialReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/EffectReader.cs
+++ b/src/Content/ContentReaders/EffectReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/EnumReader.cs
+++ b/src/Content/ContentReaders/EnumReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/EnvironmentMapEffectReader.cs
+++ b/src/Content/ContentReaders/EnvironmentMapEffectReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/ExternalReferenceReader.cs
+++ b/src/Content/ContentReaders/ExternalReferenceReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/IndexBufferReader.cs
+++ b/src/Content/ContentReaders/IndexBufferReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/Int16Reader.cs
+++ b/src/Content/ContentReaders/Int16Reader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/Int32Reader.cs
+++ b/src/Content/ContentReaders/Int32Reader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/Int64Reader.cs
+++ b/src/Content/ContentReaders/Int64Reader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/ListReader.cs
+++ b/src/Content/ContentReaders/ListReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/MatrixReader.cs
+++ b/src/Content/ContentReaders/MatrixReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/ModelReader.cs
+++ b/src/Content/ContentReaders/ModelReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/NullableReader.cs
+++ b/src/Content/ContentReaders/NullableReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/PlaneReader.cs
+++ b/src/Content/ContentReaders/PlaneReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/PointReader.cs
+++ b/src/Content/ContentReaders/PointReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/QuaternionReader.cs
+++ b/src/Content/ContentReaders/QuaternionReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/RayReader.cs
+++ b/src/Content/ContentReaders/RayReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/RectangleReader.cs
+++ b/src/Content/ContentReaders/RectangleReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/ReflectiveReader.cs
+++ b/src/Content/ContentReaders/ReflectiveReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/SByteReader.cs
+++ b/src/Content/ContentReaders/SByteReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/SingleReader.cs
+++ b/src/Content/ContentReaders/SingleReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/SkinnedEffectReader.cs
+++ b/src/Content/ContentReaders/SkinnedEffectReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/SongReader.cs
+++ b/src/Content/ContentReaders/SongReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/SoundEffectReader.cs
+++ b/src/Content/ContentReaders/SoundEffectReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/SpriteFontReader.cs
+++ b/src/Content/ContentReaders/SpriteFontReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/StringReader.cs
+++ b/src/Content/ContentReaders/StringReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/Texture2DReader.cs
+++ b/src/Content/ContentReaders/Texture2DReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/Texture3DReader.cs
+++ b/src/Content/ContentReaders/Texture3DReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/TextureCubeReader.cs
+++ b/src/Content/ContentReaders/TextureCubeReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/TextureReader.cs
+++ b/src/Content/ContentReaders/TextureReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/TimeSpanReader.cs
+++ b/src/Content/ContentReaders/TimeSpanReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/UInt16Reader.cs
+++ b/src/Content/ContentReaders/UInt16Reader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/UInt32Reader.cs
+++ b/src/Content/ContentReaders/UInt32Reader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/UInt64Reader.cs
+++ b/src/Content/ContentReaders/UInt64Reader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/Vector2Reader.cs
+++ b/src/Content/ContentReaders/Vector2Reader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/Vector3Reader.cs
+++ b/src/Content/ContentReaders/Vector3Reader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/Vector4Reader.cs
+++ b/src/Content/ContentReaders/Vector4Reader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/VertexBufferReader.cs
+++ b/src/Content/ContentReaders/VertexBufferReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/VertexDeclarationReader.cs
+++ b/src/Content/ContentReaders/VertexDeclarationReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/VideoReader.cs
+++ b/src/Content/ContentReaders/VideoReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentSerializerAttribute.cs
+++ b/src/Content/ContentSerializerAttribute.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentSerializerCollectionItemNameAttribute.cs
+++ b/src/Content/ContentSerializerCollectionItemNameAttribute.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentSerializerIgnoreAttribute.cs
+++ b/src/Content/ContentSerializerIgnoreAttribute.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentSerializerRuntimeTypeAttribute.cs
+++ b/src/Content/ContentSerializerRuntimeTypeAttribute.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentSerializerTypeVersionAttribute.cs
+++ b/src/Content/ContentSerializerTypeVersionAttribute.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentTypeReader.cs
+++ b/src/Content/ContentTypeReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentTypeReaderManager.cs
+++ b/src/Content/ContentTypeReaderManager.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ResourceContentManager.cs
+++ b/src/Content/ResourceContentManager.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Curve.cs
+++ b/src/Curve.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/CurveContinuity.cs
+++ b/src/CurveContinuity.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/CurveKey.cs
+++ b/src/CurveKey.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/CurveKeyCollection.cs
+++ b/src/CurveKeyCollection.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/CurveLoopType.cs
+++ b/src/CurveLoopType.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/CurveTangent.cs
+++ b/src/CurveTangent.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Design/BoundingBoxConverter.cs
+++ b/src/Design/BoundingBoxConverter.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Design/BoundingSphereConverter.cs
+++ b/src/Design/BoundingSphereConverter.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Design/ColorConverter.cs
+++ b/src/Design/ColorConverter.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Design/MathTypeConverter.cs
+++ b/src/Design/MathTypeConverter.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Design/MatrixConverter.cs
+++ b/src/Design/MatrixConverter.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Design/PlaneConverter.cs
+++ b/src/Design/PlaneConverter.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Design/PointConverter.cs
+++ b/src/Design/PointConverter.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Design/QuaternionConverter.cs
+++ b/src/Design/QuaternionConverter.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Design/RayConverter.cs
+++ b/src/Design/RayConverter.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Design/RectangleConverter.cs
+++ b/src/Design/RectangleConverter.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Design/Vector2Converter.cs
+++ b/src/Design/Vector2Converter.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Design/Vector3Converter.cs
+++ b/src/Design/Vector3Converter.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Design/Vector4Converter.cs
+++ b/src/Design/Vector4Converter.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/DisplayOrientation.cs
+++ b/src/DisplayOrientation.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/DrawableGameComponent.cs
+++ b/src/DrawableGameComponent.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/DrawableGameComponent.cs
+++ b/src/DrawableGameComponent.cs
@@ -9,6 +9,8 @@
 
 #region Using Statements
 using System;
+
+using Microsoft.Xna.Framework.Graphics;
 #endregion
 
 namespace Microsoft.Xna.Framework
@@ -97,7 +99,20 @@ namespace Microsoft.Xna.Framework
 			if (!_initialized)
 			{
 				_initialized = true;
-				LoadContent();
+
+				IGraphicsDeviceService graphicsDeviceService = (IGraphicsDeviceService)
+					Game.Services.GetService(typeof(IGraphicsDeviceService));
+				if (graphicsDeviceService != null)
+				{
+					if (graphicsDeviceService.GraphicsDevice != null)
+					{
+						LoadContent();
+					}
+					else
+					{
+						graphicsDeviceService.DeviceCreated += OnDeviceCreated;
+					}
+				}
 			}
 		}
 
@@ -112,6 +127,15 @@ namespace Microsoft.Xna.Framework
 				UnloadContent();
 			}
 			base.Dispose(disposing);
+		}
+
+		#endregion
+
+		#region Private Methods
+
+		private void OnDeviceCreated(object sender, EventArgs e)
+		{
+			LoadContent();
 		}
 
 		#endregion

--- a/src/FNA-NET.iOS.targets
+++ b/src/FNA-NET.iOS.targets
@@ -25,6 +25,8 @@
 
     <ObjcBindingApiDefinition Include="DummyApiDefinition.cs" />
     <ObjcBindingCoreSource Include="**\*.cs" Exclude="obj\**\*.cs" />
+
+    <PackageReference Include="FNA.NET.MoltenVK" Version="1.0.0.5" />
   </ItemGroup>
 
 </Project>

--- a/src/FNA-NET.tvOS.targets
+++ b/src/FNA-NET.tvOS.targets
@@ -25,6 +25,8 @@
 
     <ObjcBindingApiDefinition Include="DummyApiDefinition.cs" />
     <ObjcBindingCoreSource Include="**\*.cs" Exclude="obj\**\*.cs" />
+
+    <PackageReference Include="FNA.NET.MoltenVK" Version="1.0.0.5" />
   </ItemGroup>
 
 </Project>

--- a/src/FNALoggerEXT.cs
+++ b/src/FNALoggerEXT.cs
@@ -55,7 +55,10 @@ namespace Microsoft.Xna.Framework
 			{
 				FNALoggerEXT.LogError = Console.WriteLine;
 			}
+		}
 
+		internal static void HookFNA3D()
+		{
 			/* Try to hook into the FNA3D logging system */
 			try
 			{

--- a/src/FNALoggerEXT.cs
+++ b/src/FNALoggerEXT.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/FNAPlatform/FNAPlatform.cs
+++ b/src/FNAPlatform/FNAPlatform.cs
@@ -232,7 +232,6 @@ namespace Microsoft.Xna.Framework
 			Game game,
 			ref GraphicsAdapter currentAdapter,
 			bool[] textInputControlDown,
-			int[] textInputControlRepeat,
 			ref bool textInputSuppress
 		);
 		public static readonly PollEventsFunc PollEvents;

--- a/src/FNAPlatform/FNAPlatform.cs
+++ b/src/FNAPlatform/FNAPlatform.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/FNAPlatform/FNAPlatform.cs
+++ b/src/FNAPlatform/FNAPlatform.cs
@@ -136,6 +136,11 @@ namespace Microsoft.Xna.Framework
 
 			AppDomain.CurrentDomain.ProcessExit += SDL2_FNAPlatform.ProgramExit;
 			TitleLocation = SDL2_FNAPlatform.ProgramInit(args);
+
+			/* Do this AFTER ProgramInit so the platform library
+			 * has a chance to load first!
+			 */
+			FNALoggerEXT.HookFNA3D();
 		}
 
 		#endregion

--- a/src/FNAPlatform/FNAPlatform.cs
+++ b/src/FNAPlatform/FNAPlatform.cs
@@ -87,6 +87,7 @@ namespace Microsoft.Xna.Framework
 			CreateWindow =			SDL2_FNAPlatform.CreateWindow;
 			DisposeWindow =			SDL2_FNAPlatform.DisposeWindow;
 			ApplyWindowChanges =		SDL2_FNAPlatform.ApplyWindowChanges;
+			ScaleForWindow =		SDL2_FNAPlatform.ScaleForWindow;
 			GetWindowBounds =		SDL2_FNAPlatform.GetWindowBounds;
 			GetWindowResizable =		SDL2_FNAPlatform.GetWindowResizable;
 			SetWindowResizable =		SDL2_FNAPlatform.SetWindowResizable;
@@ -192,6 +193,9 @@ namespace Microsoft.Xna.Framework
 			ref string resultDeviceName
 		);
 		public static readonly ApplyWindowChangesFunc ApplyWindowChanges;
+
+		public delegate void ScaleForWindowFunc(IntPtr window, ref int w, ref int h);
+		public static readonly ScaleForWindowFunc ScaleForWindow;
 
 		public delegate Rectangle GetWindowBoundsFunc(IntPtr window);
 		public static readonly GetWindowBoundsFunc GetWindowBounds;

--- a/src/FNAPlatform/FNAPlatform.cs
+++ b/src/FNAPlatform/FNAPlatform.cs
@@ -194,7 +194,7 @@ namespace Microsoft.Xna.Framework
 		);
 		public static readonly ApplyWindowChangesFunc ApplyWindowChanges;
 
-		public delegate void ScaleForWindowFunc(IntPtr window, ref int w, ref int h);
+		public delegate void ScaleForWindowFunc(IntPtr window, bool invert, ref int w, ref int h);
 		public static readonly ScaleForWindowFunc ScaleForWindow;
 
 		public delegate Rectangle GetWindowBoundsFunc(IntPtr window);

--- a/src/FNAPlatform/FNAPlatform.cs
+++ b/src/FNAPlatform/FNAPlatform.cs
@@ -83,6 +83,13 @@ namespace Microsoft.Xna.Framework
 					"1"
 				);
 			}
+			if (args.TryGetValue("nukesteaminput", out arg) && arg == "1")
+			{
+				Environment.SetEnvironmentVariable(
+					"FNA_NUKE_STEAM_INPUT",
+					"1"
+				);
+			}
 
 			CreateWindow =			SDL2_FNAPlatform.CreateWindow;
 			DisposeWindow =			SDL2_FNAPlatform.DisposeWindow;

--- a/src/FNAPlatform/FNAPlatform.cs
+++ b/src/FNAPlatform/FNAPlatform.cs
@@ -55,10 +55,10 @@ namespace Microsoft.Xna.Framework
 					arg
 				);
 			}
-			if (args.TryGetValue("disablelateswaptear", out arg) && arg == "1")
+			if (args.TryGetValue("enablelateswaptear", out arg) && arg == "1")
 			{
 				Environment.SetEnvironmentVariable(
-					"FNA3D_DISABLE_LATESWAPTEAR",
+					"FNA3D_ENABLE_LATESWAPTEAR",
 					"1"
 				);
 			}

--- a/src/FNAPlatform/FNAWindow.cs
+++ b/src/FNAPlatform/FNAWindow.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -797,6 +797,7 @@ namespace Microsoft.Xna.Framework
 		private static void INTERNAL_HandleOrientationChange(
 			DisplayOrientation orientation,
 			GraphicsDevice graphicsDevice,
+			GraphicsAdapter graphicsAdapter,
 			FNAWindow window
 		) {
 			// Flip the backbuffer dimensions if needed
@@ -820,7 +821,10 @@ namespace Microsoft.Xna.Framework
 			graphicsDevice.PresentationParameters.DisplayOrientation = orientation;
 			window.CurrentOrientation = orientation;
 
-			graphicsDevice.Reset();
+			graphicsDevice.Reset(
+				graphicsDevice.PresentationParameters,
+				graphicsAdapter
+			);
 			window.INTERNAL_OnOrientationChanged();
 		}
 
@@ -1173,7 +1177,16 @@ namespace Microsoft.Xna.Framework
 						INTERNAL_HandleOrientationChange(
 							orientation,
 							game.GraphicsDevice,
+							currentAdapter,
 							(FNAWindow) game.Window
+						);
+					}
+					else
+					{
+						// Just reset, this is probably a hotplug
+						game.GraphicsDevice.Reset(
+							game.GraphicsDevice.PresentationParameters,
+							currentAdapter
 						);
 					}
 				}

--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -860,7 +860,6 @@ namespace Microsoft.Xna.Framework
 			Game game,
 			ref GraphicsAdapter currentAdapter,
 			bool[] textInputControlDown,
-			int[] textInputControlRepeat,
 			ref bool textInputSuppress
 		) {
 			var sdlImeHandler = game.Window.ImmService as SDLImeHandler;
@@ -879,15 +878,27 @@ namespace Microsoft.Xna.Framework
 						if (FNAPlatform.TextInputBindings.TryGetValue(key, out textIndex))
 						{
 							textInputControlDown[textIndex] = true;
-							textInputControlRepeat[textIndex] = Environment.TickCount + 400;
 							sdlImeHandler?.OnTextInput(FNAPlatform.TextInputCharacters[textIndex], key);
 						}
-						else if (Keyboard.keys.Contains(Keys.LeftControl) && key == Keys.V)
+						else if ((Keyboard.keys.Contains(Keys.LeftControl) || Keyboard.keys.Contains(Keys.RightControl))
+							&& key == Keys.V)
 						{
 							textInputControlDown[6] = true;
-							textInputControlRepeat[6] = Environment.TickCount + 400;
 							sdlImeHandler?.OnTextInput(FNAPlatform.TextInputCharacters[6], key);
 							textInputSuppress = true;
+						}
+					}
+					else if (evt.key.repeat > 0)
+					{
+						int textIndex;
+						if (FNAPlatform.TextInputBindings.TryGetValue(key, out textIndex))
+						{
+							sdlImeHandler?.OnTextInput(FNAPlatform.TextInputCharacters[textIndex], key);
+						}
+						else if ((Keyboard.keys.Contains(Keys.LeftControl) || Keyboard.keys.Contains(Keys.RightControl))
+							&& key == Keys.V)
+						{
+							sdlImeHandler?.OnTextInput(FNAPlatform.TextInputCharacters[6], key);
 						}
 					}
 
@@ -912,7 +923,8 @@ namespace Microsoft.Xna.Framework
 						{
 							textInputControlDown[value] = false;
 						}
-						else if ((!Keyboard.keys.Contains(Keys.LeftControl) && textInputControlDown[6]) || key == Keys.V)
+						else if (((!Keyboard.keys.Contains(Keys.LeftControl) && !Keyboard.keys.Contains(Keys.RightControl)) && textInputControlDown[6])
+							|| key == Keys.V)
 						{
 							textInputControlDown[6] = false;
 							textInputSuppress = false;
@@ -1236,15 +1248,6 @@ namespace Microsoft.Xna.Framework
 				{
 					game.RunApplication = false;
 					break;
-				}
-			}
-			// Text Input Controls Key Handling
-			for (int i = 0; i < FNAPlatform.TextInputCharacters.Length; i += 1)
-			{
-				if (textInputControlDown[i] && textInputControlRepeat[i] <= Environment.TickCount)
-				{
-					var c = FNAPlatform.TextInputCharacters[i];
-					sdlImeHandler?.OnTextInput(c, KeyboardUtil.ToXna(c));
 				}
 			}
 		}

--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -212,9 +212,7 @@ namespace Microsoft.Xna.Framework
 			// This _should_ be the first real SDL call we make...
 			SDL.SDL_Init(
 				SDL.SDL_INIT_VIDEO |
-				SDL.SDL_INIT_JOYSTICK |
-				SDL.SDL_INIT_GAMECONTROLLER |
-				SDL.SDL_INIT_HAPTIC
+				SDL.SDL_INIT_GAMECONTROLLER
 			);
 
 			string videoDriver = SDL.SDL_GetCurrentVideoDriver();

--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -142,6 +142,28 @@ namespace Microsoft.Xna.Framework
 				SDL.SDL_HintPriority.SDL_HINT_OVERRIDE
 			);
 
+			// Are you even surprised this is necessary?
+			if (Environment.GetEnvironmentVariable("FNA_NUKE_STEAM_INPUT") == "1")
+			{
+				SDL.SDL_SetHintWithPriority(
+					"SDL_GAMECONTROLLER_IGNORE_DEVICES",
+					"",
+					SDL.SDL_HintPriority.SDL_HINT_OVERRIDE
+				);
+				SDL.SDL_SetHintWithPriority(
+					"SDL_GAMECONTROLLER_IGNORE_DEVICES_EXCEPT",
+					"",
+					SDL.SDL_HintPriority.SDL_HINT_OVERRIDE
+				);
+
+				// This should be redundant, but who knows...
+				SDL.SDL_SetHintWithPriority(
+					"SDL_GAMECONTROLLER_ALLOW_STEAM_VIRTUAL_GAMEPAD",
+					"0",
+					SDL.SDL_HintPriority.SDL_HINT_OVERRIDE
+				);
+			}
+
 			// Built-in SDL2 command line arguments
 			string arg;
 			if (args.TryGetValue("glprofile", out arg))

--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -438,7 +438,7 @@ namespace Microsoft.Xna.Framework
 			 * the window needs to accommodate the GL viewport.
 			 * -flibit
 			 */
-			ScaleForWindow(window, ref clientWidth, ref clientHeight);
+			ScaleForWindow(window, false, ref clientWidth, ref clientHeight);
 
 			// When windowed, set the size before moving
 			if (!wantsFullscreen)
@@ -529,7 +529,7 @@ namespace Microsoft.Xna.Framework
 			}
 		}
 
-		public static void ScaleForWindow(IntPtr window, ref int w, ref int h)
+		public static void ScaleForWindow(IntPtr window, bool invert, ref int w, ref int h)
 		{
 			int ww, wh, dw, dh;
 			SDL.SDL_GetWindowSize(window, out ww, out wh);
@@ -540,8 +540,16 @@ namespace Microsoft.Xna.Framework
 				dh != 0 &&
 				(ww != dw || wh != dh)	)
 			{
-				w = (int) (w / ((float) ww / (float) dw));
-				h = (int) (h / ((float) wh / (float) dh));
+				if (invert)
+				{
+					w = (int) (w * ((float) dw / (float) ww));
+					h = (int) (h * ((float) dh / (float) wh));
+				}
+				else
+				{
+					w = (int) (w / ((float) dw / (float) ww));
+					h = (int) (h / ((float) dh / (float) wh));
+				}
 			}
 		}
 

--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Xna.Framework
 			{
 				SDL.SDL_SetHintWithPriority(
 					"SDL_GAMECONTROLLER_IGNORE_DEVICES",
-					"",
+					"0x28DE/0x11FF",
 					SDL.SDL_HintPriority.SDL_HINT_OVERRIDE
 				);
 				SDL.SDL_SetHintWithPriority(

--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -1111,7 +1111,7 @@ namespace Microsoft.Xna.Framework
 						 */
 						uint flags = SDL.SDL_GetWindowFlags(game.Window.Handle);
 						if (	(flags & (uint) SDL.SDL_WindowFlags.SDL_WINDOW_RESIZABLE) != 0 &&
-							(flags & (uint) SDL.SDL_WindowFlags.SDL_WINDOW_INPUT_FOCUS) != 0	)
+							(flags & (uint) (SDL.SDL_WindowFlags.SDL_WINDOW_INPUT_FOCUS | SDL.SDL_WindowFlags.SDL_WINDOW_MOUSE_FOCUS)) != 0	)
 						{
 							((FNAWindow) game.Window).INTERNAL_ClientSizeChanged();
 						}

--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -136,9 +136,12 @@ namespace Microsoft.Xna.Framework
 			 *
 			 * -flibit
 			 */
+			string useLabels = (Environment.GetEnvironmentVariable(
+				"FNA_GAMEPAD_IGNORE_PHYSICAL_LAYOUT"
+			) == "1") ? "1" : "0";
 			SDL.SDL_SetHintWithPriority(
 				SDL.SDL_HINT_GAMECONTROLLER_USE_BUTTON_LABELS,
-				"0",
+				useLabels,
 				SDL.SDL_HintPriority.SDL_HINT_OVERRIDE
 			);
 

--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -36,10 +36,6 @@ namespace Microsoft.Xna.Framework
 
 		private static bool SupportsGlobalMouse;
 
-		// For iOS high dpi support
-		private static int RetinaWidth;
-		private static int RetinaHeight;
-
 		#endregion
 
 		#region Game Objects
@@ -199,19 +195,31 @@ namespace Microsoft.Xna.Framework
 				SDL.SDL_INIT_HAPTIC
 			);
 
+			string videoDriver = SDL.SDL_GetCurrentVideoDriver();
+
 			/* A number of platforms don't support global mouse, but
 			 * this really only matters on desktop where the game
 			 * screen may not be covering the whole display.
 			 */
-			if (	OSVersion.Equals("Windows") ||
-				OSVersion.Equals("Mac OS X") ||
-				SDL.SDL_GetCurrentVideoDriver() == "x11"	)
+			SupportsGlobalMouse = (	OSVersion.Equals("Windows") ||
+						OSVersion.Equals("Mac OS X") ||
+						videoDriver.Equals("x11")	);
+
+			/* High-DPI is really annoying and only some platforms
+			 * actually let you control the drawable surface.
+			 */
+			if (	!videoDriver.Equals("wayland") &&
+				!videoDriver.Equals("cocoa") &&
+				!videoDriver.Equals("uikit")	)
 			{
-				SupportsGlobalMouse = true;
-			}
-			else
-			{
-				SupportsGlobalMouse = false;
+				/* Note that this is NOT an override.
+				 * We can be overruled, just in case.
+				 */
+				SDL.SDL_SetHintWithPriority(
+					SDL.SDL_HINT_VIDEO_HIGHDPI_DISABLED,
+					"1",
+					SDL.SDL_HintPriority.SDL_HINT_NORMAL
+				);
 			}
 
 			/* We need to change the Windows default here, as the
@@ -376,18 +384,10 @@ namespace Microsoft.Xna.Framework
 			 * This is our way to communicate that it failed...
 			 * -flibit
 			 */
-			int drawX, drawY;
-			FNA3D.FNA3D_GetDrawableSize(window, out drawX, out drawY);
-			if (	drawX == GraphicsDeviceManager.DefaultBackBufferWidth &&
-				drawY == GraphicsDeviceManager.DefaultBackBufferHeight	)
+			initFlags = (SDL.SDL_WindowFlags) SDL.SDL_GetWindowFlags(window);
+			if ((initFlags & SDL.SDL_WindowFlags.SDL_WINDOW_ALLOW_HIGHDPI) == 0)
 			{
 				Environment.SetEnvironmentVariable("FNA_GRAPHICS_ENABLE_HIGHDPI", "0");
-			}
-			else
-			{
-				// Store the full retina resolution of the display
-				RetinaWidth = drawX;
-				RetinaHeight = drawY;
 			}
 
 			return new FNAWindow(
@@ -433,16 +433,12 @@ namespace Microsoft.Xna.Framework
 			ref string resultDeviceName
 		) {
 			bool center = false;
-			if (Environment.GetEnvironmentVariable("FNA_GRAPHICS_ENABLE_HIGHDPI") == "1")
-			{
-				/* For high-DPI windows, halve the size!
-				 * The drawable size is now the primary width/height, so
-				 * the window needs to accommodate the GL viewport.
-				 * -flibit
-				 */
-				clientWidth /= 2;
-				clientHeight /= 2;
-			}
+
+			/* The drawable size is now the primary width/height, so
+			 * the window needs to accommodate the GL viewport.
+			 * -flibit
+			 */
+			ScaleForWindow(window, ref clientWidth, ref clientHeight);
 
 			// When windowed, set the size before moving
 			if (!wantsFullscreen)
@@ -530,6 +526,22 @@ namespace Microsoft.Xna.Framework
 				Rectangle b = GetWindowBounds(window);
 				Mouse.INTERNAL_WindowWidth = b.Width;
 				Mouse.INTERNAL_WindowHeight = b.Height;
+			}
+		}
+
+		public static void ScaleForWindow(IntPtr window, ref int w, ref int h)
+		{
+			int ww, wh, dw, dh;
+			SDL.SDL_GetWindowSize(window, out ww, out wh);
+			FNA3D.FNA3D_GetDrawableSize(window, out dw, out dh);
+			if (	ww != 0 &&
+				wh != 0 &&
+				dw != 0 &&
+				dh != 0 &&
+				(ww != dw || wh != dh)	)
+			{
+				w = (int) (w / ((float) ww / (float) dw));
+				h = (int) (h / ((float) wh / (float) dh));
 			}
 		}
 
@@ -1299,13 +1311,7 @@ namespace Microsoft.Xna.Framework
 			SDL.SDL_DisplayMode filler = new SDL.SDL_DisplayMode();
 			SDL.SDL_GetCurrentDisplayMode(adapterIndex, out filler);
 
-			if (	OSVersion.Equals("iOS") &&
-				Environment.GetEnvironmentVariable("FNA_GRAPHICS_ENABLE_HIGHDPI") == "1"	)
-			{
-				// Provide the actual resolution in pixels, not points.
-				filler.w = RetinaWidth;
-				filler.h = RetinaHeight;
-			}
+			// FIXME: iOS needs to factor in the DPI!
 
 			return new DisplayMode(
 				filler.w,

--- a/src/FrameworkDispatcher.cs
+++ b/src/FrameworkDispatcher.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Game.cs
+++ b/src/Game.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Game.cs
+++ b/src/Game.cs
@@ -223,7 +223,6 @@ namespace Microsoft.Xna.Framework
 		private static readonly TimeSpan MaxElapsedTime = TimeSpan.FromMilliseconds(500);
 
 		private bool[] textInputControlDown;
-		private int[] textInputControlRepeat;
 		private bool textInputSuppress;
 
 		#endregion
@@ -263,7 +262,6 @@ namespace Microsoft.Xna.Framework
 			}
 
 			textInputControlDown = new bool[FNAPlatform.TextInputCharacters.Length];
-			textInputControlRepeat = new int[FNAPlatform.TextInputCharacters.Length];
 
 			hasInitialized = false;
 			suppressDraw = false;
@@ -462,7 +460,6 @@ namespace Microsoft.Xna.Framework
 				this,
 				ref currentAdapter,
 				textInputControlDown,
-				textInputControlRepeat,
 				ref textInputSuppress
 			);
 

--- a/src/Game.cs
+++ b/src/Game.cs
@@ -652,11 +652,17 @@ namespace Microsoft.Xna.Framework
 			 */
 			graphicsDeviceService = (IGraphicsDeviceService)
 				Services.GetService(typeof(IGraphicsDeviceService));
-			if (	graphicsDeviceService != null &&
-				graphicsDeviceService.GraphicsDevice != null	)
+			if (graphicsDeviceService != null)
 			{
 				graphicsDeviceService.DeviceDisposing += (o, e) => UnloadContent();
-				LoadContent();
+				if (graphicsDeviceService.GraphicsDevice != null)
+				{
+					LoadContent();
+				}
+				else
+				{
+					graphicsDeviceService.DeviceCreated += (o, e) => LoadContent();
+				}
 			}
 		}
 

--- a/src/GameComponent.cs
+++ b/src/GameComponent.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/GameComponentCollection.cs
+++ b/src/GameComponentCollection.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/GameComponentCollectionEventArgs.cs
+++ b/src/GameComponentCollectionEventArgs.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/GameServiceContainer.cs
+++ b/src/GameServiceContainer.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/GameTime.cs
+++ b/src/GameTime.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/GameWindow.cs
+++ b/src/GameWindow.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/ClearOptions.cs
+++ b/src/Graphics/ClearOptions.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/ColorWriteChannels.cs
+++ b/src/Graphics/ColorWriteChannels.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/CubeMapFace.cs
+++ b/src/Graphics/CubeMapFace.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/DepthFormat.cs
+++ b/src/Graphics/DepthFormat.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/DeviceLostException.cs
+++ b/src/Graphics/DeviceLostException.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/DeviceNotResetException.cs
+++ b/src/Graphics/DeviceNotResetException.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/DirectionalLight.cs
+++ b/src/Graphics/DirectionalLight.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/DisplayMode.cs
+++ b/src/Graphics/DisplayMode.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/DisplayModeCollection.cs
+++ b/src/Graphics/DisplayModeCollection.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/DxtUtil.cs
+++ b/src/Graphics/DxtUtil.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Effect/Effect.cs
+++ b/src/Graphics/Effect/Effect.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Effect/EffectAnnotation.cs
+++ b/src/Graphics/Effect/EffectAnnotation.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Effect/EffectAnnotationCollection.cs
+++ b/src/Graphics/Effect/EffectAnnotationCollection.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Effect/EffectMaterial.cs
+++ b/src/Graphics/Effect/EffectMaterial.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Effect/EffectParameter.cs
+++ b/src/Graphics/Effect/EffectParameter.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Effect/EffectParameterClass.cs
+++ b/src/Graphics/Effect/EffectParameterClass.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Effect/EffectParameterCollection.cs
+++ b/src/Graphics/Effect/EffectParameterCollection.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Effect/EffectParameterType.cs
+++ b/src/Graphics/Effect/EffectParameterType.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Effect/EffectPass.cs
+++ b/src/Graphics/Effect/EffectPass.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Effect/EffectPassCollection.cs
+++ b/src/Graphics/Effect/EffectPassCollection.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Effect/EffectTechnique.cs
+++ b/src/Graphics/Effect/EffectTechnique.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Effect/EffectTechniqueCollection.cs
+++ b/src/Graphics/Effect/EffectTechniqueCollection.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Effect/IEffectFog.cs
+++ b/src/Graphics/Effect/IEffectFog.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Effect/IEffectLights.cs
+++ b/src/Graphics/Effect/IEffectLights.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Effect/IEffectMatrices.cs
+++ b/src/Graphics/Effect/IEffectMatrices.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Effect/Resources.cs
+++ b/src/Graphics/Effect/Resources.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/GraphicsAdapter.cs
+++ b/src/Graphics/GraphicsAdapter.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/GraphicsDevice.cs
+++ b/src/Graphics/GraphicsDevice.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/GraphicsDeviceStatus.cs
+++ b/src/Graphics/GraphicsDeviceStatus.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/GraphicsProfile.cs
+++ b/src/Graphics/GraphicsProfile.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/GraphicsResource.cs
+++ b/src/Graphics/GraphicsResource.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/IGraphicsDeviceService.cs
+++ b/src/Graphics/IGraphicsDeviceService.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/IRenderTarget.cs
+++ b/src/Graphics/IRenderTarget.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Model.cs
+++ b/src/Graphics/Model.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/ModelBone.cs
+++ b/src/Graphics/ModelBone.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/ModelBoneCollection.cs
+++ b/src/Graphics/ModelBoneCollection.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/ModelEffectCollection.cs
+++ b/src/Graphics/ModelEffectCollection.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/ModelMesh.cs
+++ b/src/Graphics/ModelMesh.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/ModelMeshCollection.cs
+++ b/src/Graphics/ModelMeshCollection.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/ModelMeshPart.cs
+++ b/src/Graphics/ModelMeshPart.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/ModelMeshPartCollection.cs
+++ b/src/Graphics/ModelMeshPartCollection.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/NoSuitableGraphicsDeviceException.cs
+++ b/src/Graphics/NoSuitableGraphicsDeviceException.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/OcclusionQuery.cs
+++ b/src/Graphics/OcclusionQuery.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/PackedVector/Alpha8.cs
+++ b/src/Graphics/PackedVector/Alpha8.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/PackedVector/Bgr565.cs
+++ b/src/Graphics/PackedVector/Bgr565.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/PackedVector/Bgra4444.cs
+++ b/src/Graphics/PackedVector/Bgra4444.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/PackedVector/Bgra5551.cs
+++ b/src/Graphics/PackedVector/Bgra5551.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/PackedVector/Byte4.cs
+++ b/src/Graphics/PackedVector/Byte4.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/PackedVector/HalfSingle.cs
+++ b/src/Graphics/PackedVector/HalfSingle.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/PackedVector/HalfTypeHelper.cs
+++ b/src/Graphics/PackedVector/HalfTypeHelper.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/PackedVector/HalfVector2.cs
+++ b/src/Graphics/PackedVector/HalfVector2.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/PackedVector/HalfVector4.cs
+++ b/src/Graphics/PackedVector/HalfVector4.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/PackedVector/IPackedVector.cs
+++ b/src/Graphics/PackedVector/IPackedVector.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/PackedVector/NormalizedByte2.cs
+++ b/src/Graphics/PackedVector/NormalizedByte2.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/PackedVector/NormalizedByte4.cs
+++ b/src/Graphics/PackedVector/NormalizedByte4.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/PackedVector/NormalizedShort2.cs
+++ b/src/Graphics/PackedVector/NormalizedShort2.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/PackedVector/NormalizedShort4.cs
+++ b/src/Graphics/PackedVector/NormalizedShort4.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/PackedVector/Rg32.cs
+++ b/src/Graphics/PackedVector/Rg32.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/PackedVector/Rgba1010102.cs
+++ b/src/Graphics/PackedVector/Rgba1010102.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/PackedVector/Rgba64.cs
+++ b/src/Graphics/PackedVector/Rgba64.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/PackedVector/Short2.cs
+++ b/src/Graphics/PackedVector/Short2.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/PackedVector/Short4.cs
+++ b/src/Graphics/PackedVector/Short4.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/PipelineCache.cs
+++ b/src/Graphics/PipelineCache.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/PresentInterval.cs
+++ b/src/Graphics/PresentInterval.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/PresentationParameters.cs
+++ b/src/Graphics/PresentationParameters.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/PrimitiveType.cs
+++ b/src/Graphics/PrimitiveType.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/ProfileCapabilities.cs
+++ b/src/Graphics/ProfileCapabilities.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/RenderTarget2D.cs
+++ b/src/Graphics/RenderTarget2D.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/RenderTargetBinding.cs
+++ b/src/Graphics/RenderTargetBinding.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/RenderTargetCube.cs
+++ b/src/Graphics/RenderTargetCube.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/RenderTargetUsage.cs
+++ b/src/Graphics/RenderTargetUsage.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/ResourceCreatedEventArgs.cs
+++ b/src/Graphics/ResourceCreatedEventArgs.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/ResourceDestroyedEventArgs.cs
+++ b/src/Graphics/ResourceDestroyedEventArgs.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/SamplerStateCollection.cs
+++ b/src/Graphics/SamplerStateCollection.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/SetDataOptions.cs
+++ b/src/Graphics/SetDataOptions.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/SpriteBatch.cs
+++ b/src/Graphics/SpriteBatch.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/SpriteBatch.cs
+++ b/src/Graphics/SpriteBatch.cs
@@ -1444,12 +1444,13 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		private void DrawPrimitives(Texture texture, int baseSprite, int batchSize)
 		{
-			GraphicsDevice.Textures[0] = texture;
 			if (customEffect != null)
 			{
 				foreach (EffectPass pass in customEffect.CurrentTechnique.Passes)
 				{
 					pass.Apply();
+					// Set this _after_ Apply, otherwise EffectParameters override it!
+					GraphicsDevice.Textures[0] = texture;
 					GraphicsDevice.DrawIndexedPrimitives(
 						PrimitiveType.TriangleList,
 						baseSprite * 4,
@@ -1462,6 +1463,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			}
 			else
 			{
+				GraphicsDevice.Textures[0] = texture;
 				GraphicsDevice.DrawIndexedPrimitives(
 					PrimitiveType.TriangleList,
 					baseSprite * 4,

--- a/src/Graphics/SpriteEffects.cs
+++ b/src/Graphics/SpriteEffects.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/SpriteFont.cs
+++ b/src/Graphics/SpriteFont.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/SpriteSortMode.cs
+++ b/src/Graphics/SpriteSortMode.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/States/Blend.cs
+++ b/src/Graphics/States/Blend.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/States/BlendFunction.cs
+++ b/src/Graphics/States/BlendFunction.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/States/BlendState.cs
+++ b/src/Graphics/States/BlendState.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/States/CompareFunction.cs
+++ b/src/Graphics/States/CompareFunction.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/States/CullMode.cs
+++ b/src/Graphics/States/CullMode.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/States/DepthStencilState.cs
+++ b/src/Graphics/States/DepthStencilState.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/States/FillMode.cs
+++ b/src/Graphics/States/FillMode.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/States/RasterizerState.cs
+++ b/src/Graphics/States/RasterizerState.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/States/SamplerState.cs
+++ b/src/Graphics/States/SamplerState.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/States/StencilOperation.cs
+++ b/src/Graphics/States/StencilOperation.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/States/TextureAddressMode.cs
+++ b/src/Graphics/States/TextureAddressMode.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/States/TextureFilter.cs
+++ b/src/Graphics/States/TextureFilter.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/SurfaceFormat.cs
+++ b/src/Graphics/SurfaceFormat.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/SurfaceFormat.cs
+++ b/src/Graphics/SurfaceFormat.cs
@@ -108,6 +108,14 @@ namespace Microsoft.Xna.Framework.Graphics
 		/// Byte encoding is in sRGB colorspace, read in shader in linear colorspace.
 		/// </summary>
 		Dxt5SrgbEXT,
+		/// <summary>
+		/// BC7 block texture format
+		/// </summary>
+		Bc7EXT,
+		/// <summary>
+		/// BC7 block texture format where the R/G/B values are non-linear sRGB.
+		/// </summary>
+		Bc7SrgbEXT,
 		/// RGB ETC2
 		/// </summary>
 		Rgb8Etc2,

--- a/src/Graphics/SurfaceFormat.cs
+++ b/src/Graphics/SurfaceFormat.cs
@@ -99,6 +99,15 @@ namespace Microsoft.Xna.Framework.Graphics
 		/// </summary>
 		ColorBgraEXT,
 		/// <summary>
+		/// Unsigned 32-bit ARGB pixel format for store 8 bits per channel.
+		/// Byte encoding is in sRGB colorspace, read in shader in linear colorspace.
+		/// </summary>
+		ColorSrgbEXT,
+		/// <summary>
+		/// DXT5. Texture format with compression. Surface dimensions must be a multiple 4.
+		/// Byte encoding is in sRGB colorspace, read in shader in linear colorspace.
+		/// </summary>
+		Dxt5SrgbEXT,
 		/// RGB ETC2
 		/// </summary>
 		Rgb8Etc2,

--- a/src/Graphics/Texture.cs
+++ b/src/Graphics/Texture.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Texture.cs
+++ b/src/Graphics/Texture.cs
@@ -157,15 +157,39 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		#region Static DDS Parser
 
+		internal static int CalculateDDSLevelSize(
+			int width,
+			int height,
+			SurfaceFormat format
+		) {
+			if (format == SurfaceFormat.ColorBgraEXT)
+			{
+				return (((width * 32) + 7) / 8) * height;
+			}
+			else
+			{
+				int blockSize = 16;
+				if (format == SurfaceFormat.Dxt1)
+				{
+					blockSize = 8;
+				}
+				width = Math.Max(width, 1);
+				height = Math.Max(height, 1);
+				return (
+					((width + 3) / 4) *
+					((height + 3) / 4) *
+					blockSize
+				);
+			}
+		}
+
 		// DDS loading extension, based on MojoDDS
 		internal static void ParseDDS(
 			BinaryReader reader,
 			out SurfaceFormat format,
 			out int width,
 			out int height,
-			out int levels,
-			out int levelSize,
-			out int blockSize
+			out int levels
 		) {
 			// A whole bunch of magic numbers, yay DDS!
 			const uint DDS_MAGIC = 0x20534444;
@@ -262,23 +286,19 @@ namespace Microsoft.Xna.Framework.Graphics
 			}
 
 			// Determine texture format
-			blockSize = 0;
 			if ((formatFlags & DDPF_FOURCC) == DDPF_FOURCC)
 			{
 				if (formatFourCC == FOURCC_DXT1)
 				{
 					format = SurfaceFormat.Dxt1;
-					blockSize = 8;
 				}
 				else if (formatFourCC == FOURCC_DXT3)
 				{
 					format = SurfaceFormat.Dxt3;
-					blockSize = 16;
 				}
 				else if (formatFourCC == FOURCC_DXT5)
 				{
 					format = SurfaceFormat.Dxt5;
-					blockSize = 16;
 				}
 				else
 				{
@@ -286,10 +306,6 @@ namespace Microsoft.Xna.Framework.Graphics
 						"Unsupported DDS texture format"
 					);
 				}
-				levelSize = (
-					((width > 0 ? ((width + 3) / 4) : 1) * blockSize) *
-					(height > 0 ? ((height + 3) / 4) : 1)
-				);
 			}
 			else if ((formatFlags & DDPF_RGB) == DDPF_RGB)
 			{
@@ -305,10 +321,6 @@ namespace Microsoft.Xna.Framework.Graphics
 				}
 
 				format = SurfaceFormat.ColorBgraEXT;
-				levelSize = (int) (
-					(((width * formatRGBBitCount) + 7) / 8) *
-					height
-				);
 			}
 			else
 			{

--- a/src/Graphics/Texture.cs
+++ b/src/Graphics/Texture.cs
@@ -75,6 +75,7 @@ namespace Microsoft.Xna.Framework.Graphics
 					return 8;
 				case SurfaceFormat.Dxt3:
 				case SurfaceFormat.Dxt5:
+				case SurfaceFormat.Dxt5SrgbEXT:
 					return 16;
 				case SurfaceFormat.Alpha8:
 					return 1;
@@ -91,6 +92,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				case SurfaceFormat.NormalizedByte4:
 				case SurfaceFormat.Rgba1010102:
 				case SurfaceFormat.ColorBgraEXT:
+				case SurfaceFormat.ColorSrgbEXT:
 					return 4;
 				case SurfaceFormat.HalfVector4:
 				case SurfaceFormat.Rgba64:

--- a/src/Graphics/Texture.cs
+++ b/src/Graphics/Texture.cs
@@ -76,6 +76,8 @@ namespace Microsoft.Xna.Framework.Graphics
 				case SurfaceFormat.Dxt3:
 				case SurfaceFormat.Dxt5:
 				case SurfaceFormat.Dxt5SrgbEXT:
+				case SurfaceFormat.Bc7EXT:
+				case SurfaceFormat.Bc7SrgbEXT:
 					return 16;
 				case SurfaceFormat.Alpha8:
 					return 1;
@@ -214,6 +216,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			const uint FOURCC_DXT1 = 0x31545844;
 			const uint FOURCC_DXT3 = 0x33545844;
 			const uint FOURCC_DXT5 = 0x35545844;
+			const uint FOURCC_BPTC = 0x30315844;
 			// const uint FOURCC_DX10 = 0x30315844;
 			const uint pitchAndLinear = (
 				DDSD_PITCH | DDSD_LINEARSIZE
@@ -290,23 +293,24 @@ namespace Microsoft.Xna.Framework.Graphics
 			// Determine texture format
 			if ((formatFlags & DDPF_FOURCC) == DDPF_FOURCC)
 			{
-				if (formatFourCC == FOURCC_DXT1)
+				switch (formatFourCC)
 				{
-					format = SurfaceFormat.Dxt1;
-				}
-				else if (formatFourCC == FOURCC_DXT3)
-				{
-					format = SurfaceFormat.Dxt3;
-				}
-				else if (formatFourCC == FOURCC_DXT5)
-				{
-					format = SurfaceFormat.Dxt5;
-				}
-				else
-				{
-					throw new NotSupportedException(
-						"Unsupported DDS texture format"
-					);
+					case FOURCC_DXT1:
+						format = SurfaceFormat.Dxt1;
+						break;
+					case FOURCC_DXT3:
+						format = SurfaceFormat.Dxt3;
+						break;
+					case FOURCC_DXT5:
+						format = SurfaceFormat.Dxt5;
+						break;
+					case FOURCC_BPTC:
+						format = SurfaceFormat.Bc7EXT;
+						break;
+					default:
+						throw new NotSupportedException(
+							"Unsupported DDS texture format"
+						);
 				}
 			}
 			else if ((formatFlags & DDPF_RGB) == DDPF_RGB)

--- a/src/Graphics/Texture.cs
+++ b/src/Graphics/Texture.cs
@@ -170,6 +170,14 @@ namespace Microsoft.Xna.Framework.Graphics
 			{
 				return (((width * 32) + 7) / 8) * height;
 			}
+			else if (format == SurfaceFormat.HalfVector4)
+			{
+				return (((width * 64) + 7) / 8) * height;
+			}
+			else if (format == SurfaceFormat.Vector4)
+			{
+				return (((width * 128) + 7) / 8) * height;
+			}
 			else
 			{
 				int blockSize = 16;
@@ -295,6 +303,12 @@ namespace Microsoft.Xna.Framework.Graphics
 			{
 				switch (formatFourCC)
 				{
+					case 0x71: // D3DFMT_A16B16G16R16F
+						format = SurfaceFormat.HalfVector4;
+						break;
+					case 0x74: // D3DFMT_A32B32G32R32F
+						format = SurfaceFormat.Vector4;
+						break;
 					case FOURCC_DXT1:
 						format = SurfaceFormat.Dxt1;
 						break;

--- a/src/Graphics/Texture.cs
+++ b/src/Graphics/Texture.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			}
 		}
 
-		internal static int GetPixelStoreAlignment(SurfaceFormat format) 
+		internal static int GetPixelStoreAlignment(SurfaceFormat format)
 		{
 			/*
 			 * https://github.com/FNA-XNA/FNA/pull/238
@@ -201,7 +201,8 @@ namespace Microsoft.Xna.Framework.Graphics
 			out SurfaceFormat format,
 			out int width,
 			out int height,
-			out int levels
+			out int levels,
+			out bool isCube
 		) {
 			// A whole bunch of magic numbers, yay DDS!
 			const uint DDS_MAGIC = 0x20534444;
@@ -224,8 +225,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			const uint FOURCC_DXT1 = 0x31545844;
 			const uint FOURCC_DXT3 = 0x33545844;
 			const uint FOURCC_DXT5 = 0x35545844;
-			const uint FOURCC_BPTC = 0x30315844;
-			// const uint FOURCC_DX10 = 0x30315844;
+			const uint FOURCC_DX10 = 0x30315844;
 			const uint pitchAndLinear = (
 				DDSD_PITCH | DDSD_LINEARSIZE
 			);
@@ -280,12 +280,22 @@ namespace Microsoft.Xna.Framework.Graphics
 			{
 				throw new NotSupportedException("Not a texture!");
 			}
+
+			isCube = false;
+
 			uint caps2 = reader.ReadUInt32();
-			if (	caps2 != 0 &&
-				(caps2 & DDSCAPS2_CUBEMAP) != DDSCAPS2_CUBEMAP	)
+			if (caps2 != 0)
 			{
-				throw new NotSupportedException("Invalid caps2!");
+				if ((caps2 & DDSCAPS2_CUBEMAP) == DDSCAPS2_CUBEMAP)
+				{
+					isCube = true;
+				}
+				else
+				{
+					throw new NotSupportedException("Invalid caps2!");
+				}
 			}
+
 			reader.ReadUInt32(); // dwCaps3, unused
 			reader.ReadUInt32(); // dwCaps4, unused
 
@@ -318,8 +328,82 @@ namespace Microsoft.Xna.Framework.Graphics
 					case FOURCC_DXT5:
 						format = SurfaceFormat.Dxt5;
 						break;
-					case FOURCC_BPTC:
-						format = SurfaceFormat.Bc7EXT;
+					case FOURCC_DX10:
+						// If the fourCC is DX10, there is an extra header with additional format information.
+						uint dxgiFormat = reader.ReadUInt32();
+
+						// These values are taken from the DXGI_FORMAT enum.
+						switch (dxgiFormat)
+						{
+							case 2:
+								format = SurfaceFormat.Vector4;
+								break;
+
+							case 10:
+								format = SurfaceFormat.HalfVector4;
+								break;
+
+							case 71:
+								format = SurfaceFormat.Dxt1;
+								break;
+
+							case 74:
+								format = SurfaceFormat.Dxt3;
+								break;
+
+							case 77:
+								format = SurfaceFormat.Dxt5;
+								break;
+
+							case 98:
+								format = SurfaceFormat.Bc7EXT;
+								break;
+
+							case 99:
+								format = SurfaceFormat.Bc7SrgbEXT;
+								break;
+
+							default:
+								throw new NotSupportedException(
+									"Unsupported DDS texture format"
+								);
+						}
+
+						uint resourceDimension = reader.ReadUInt32();
+
+						// These values are taken from the D3D10_RESOURCE_DIMENSION enum.
+						switch (resourceDimension)
+						{
+							case 0: // Unknown
+							case 1: // Buffer
+								throw new NotSupportedException(
+									"Unsupported DDS texture format"
+								);
+							default:
+								break;
+						}
+
+						/*
+						 * This flag seemingly only indicates if the texture is a cube map.
+						 * This is already determined above. Cool!
+						 */
+						uint miscFlag = reader.ReadUInt32();
+
+						/*
+						 * Indicates the number of elements in the texture array.
+						 * We don't support texture arrays so just throw if it's greater than 1.
+						 */
+						uint arraySize = reader.ReadUInt32();
+
+						if (arraySize > 1)
+						{
+							throw new NotSupportedException(
+								"Unsupported DDS texture format"
+							);
+						}
+
+						reader.ReadUInt32(); // reserved
+
 						break;
 					default:
 						throw new NotSupportedException(

--- a/src/Graphics/Texture.cs
+++ b/src/Graphics/Texture.cs
@@ -387,7 +387,7 @@ namespace Microsoft.Xna.Framework.Graphics
 						 * This flag seemingly only indicates if the texture is a cube map.
 						 * This is already determined above. Cool!
 						 */
-						uint miscFlag = reader.ReadUInt32();
+						reader.ReadUInt32();
 
 						/*
 						 * Indicates the number of elements in the texture array.

--- a/src/Graphics/Texture2D.cs
+++ b/src/Graphics/Texture2D.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Texture2D.cs
+++ b/src/Graphics/Texture2D.cs
@@ -74,20 +74,39 @@ namespace Microsoft.Xna.Framework.Graphics
 			LevelCount = mipMap ? CalculateMipLevels(width, height) : 1;
 
 			// TODO: Use QueryRenderTargetFormat!
-			if (	this is IRenderTarget &&
-				format != SurfaceFormat.Color &&
-				format != SurfaceFormat.Rgba1010102 &&
-				format != SurfaceFormat.Rg32 &&
-				format != SurfaceFormat.Rgba64 &&
-				format != SurfaceFormat.Single &&
-				format != SurfaceFormat.Vector2 &&
-				format != SurfaceFormat.Vector4 &&
-				format != SurfaceFormat.HalfSingle &&
-				format != SurfaceFormat.HalfVector2 &&
-				format != SurfaceFormat.HalfVector4 &&
-				format != SurfaceFormat.HdrBlendable	)
+			if (this is IRenderTarget)
 			{
-				Format = SurfaceFormat.Color;
+				if (format == SurfaceFormat.ColorSrgbEXT)
+				{
+					if (FNA3D.FNA3D_SupportsSRGBRenderTargets(GraphicsDevice.GLDevice) == 0)
+					{
+						// Renderable but not on this device
+						Format = SurfaceFormat.Color;
+					}
+					else
+					{
+						Format = format;
+					}
+				}
+				else if (	format != SurfaceFormat.Color &&
+						format != SurfaceFormat.Rgba1010102 &&
+						format != SurfaceFormat.Rg32 &&
+						format != SurfaceFormat.Rgba64 &&
+						format != SurfaceFormat.Single &&
+						format != SurfaceFormat.Vector2 &&
+						format != SurfaceFormat.Vector4 &&
+						format != SurfaceFormat.HalfSingle &&
+						format != SurfaceFormat.HalfVector2 &&
+						format != SurfaceFormat.HalfVector4 &&
+						format != SurfaceFormat.HdrBlendable	)
+				{
+					// Not a renderable format period
+					Format = SurfaceFormat.Color;
+				}
+				else
+				{
+					Format = format;
+				}
 			}
 			else
 			{

--- a/src/Graphics/Texture2D.cs
+++ b/src/Graphics/Texture2D.cs
@@ -456,7 +456,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		#endregion
 
 		#region Public Static Texture2D Extensions
-		
+
 		/// <summary>
 		/// Loads image data from a given stream.
 		/// </summary>
@@ -514,14 +514,21 @@ namespace Microsoft.Xna.Framework.Graphics
 			{
 
 			int width, height, levels;
+			bool isCube;
 			SurfaceFormat format;
 			Texture.ParseDDS(
 				reader,
 				out format,
 				out width,
 				out height,
-				out levels
+				out levels,
+				out isCube
 			);
+
+			if (isCube)
+			{
+				throw new FormatException("This file contains cube map data!");
+			}
 
 			// Allocate/Load texture
 			result = new Texture2D(

--- a/src/Graphics/Texture2D.cs
+++ b/src/Graphics/Texture2D.cs
@@ -494,16 +494,14 @@ namespace Microsoft.Xna.Framework.Graphics
 			using (BinaryReader reader = new BinaryReader(stream))
 			{
 
-			int width, height, levels, levelSize, blockSize;
+			int width, height, levels;
 			SurfaceFormat format;
 			Texture.ParseDDS(
 				reader,
 				out format,
 				out width,
 				out height,
-				out levels,
-				out levelSize,
-				out blockSize
+				out levels
 			);
 
 			// Allocate/Load texture
@@ -521,6 +519,11 @@ namespace Microsoft.Xna.Framework.Graphics
 			{
 				for (int i = 0; i < levels; i += 1)
 				{
+					int levelSize = Texture.CalculateDDSLevelSize(
+						width >> i,
+						height >> i,
+						format
+					);
 					result.SetData(
 						i,
 						null,
@@ -532,27 +535,23 @@ namespace Microsoft.Xna.Framework.Graphics
 						levelSize,
 						SeekOrigin.Current
 					);
-					levelSize = Math.Max(
-						levelSize >> 2,
-						blockSize
-					);
 				}
 			}
 			else
 			{
 				for (int i = 0; i < levels; i += 1)
 				{
-					tex = reader.ReadBytes(levelSize);
+					tex = reader.ReadBytes(Texture.CalculateDDSLevelSize(
+						width >> i,
+						height >> i,
+						format
+					));
 					result.SetData(
 						i,
 						null,
 						tex,
 						0,
 						tex.Length
-					);
-					levelSize = Math.Max(
-						levelSize >> 2,
-						blockSize
 					);
 				}
 			}

--- a/src/Graphics/Texture3D.cs
+++ b/src/Graphics/Texture3D.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/TextureCollection.cs
+++ b/src/Graphics/TextureCollection.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/TextureCube.cs
+++ b/src/Graphics/TextureCube.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/TextureCube.cs
+++ b/src/Graphics/TextureCube.cs
@@ -322,14 +322,21 @@ namespace Microsoft.Xna.Framework.Graphics
 			{
 
 			int width, height, levels;
+			bool isCube;
 			SurfaceFormat format;
 			Texture.ParseDDS(
 				reader,
 				out format,
 				out width,
 				out height,
-				out levels
+				out levels,
+				out isCube
 			);
+
+			if (!isCube)
+			{
+				throw new FormatException("This file does not contain cube data!");
+			}
 
 			// Allocate/Load texture
 			result = new TextureCube(

--- a/src/Graphics/TextureCube.cs
+++ b/src/Graphics/TextureCube.cs
@@ -49,20 +49,39 @@ namespace Microsoft.Xna.Framework.Graphics
 			LevelCount = mipMap ? CalculateMipLevels(size) : 1;
 
 			// TODO: Use QueryRenderTargetFormat!
-			if (	this is IRenderTarget &&
-				format != SurfaceFormat.Color &&
-				format != SurfaceFormat.Rgba1010102 &&
-				format != SurfaceFormat.Rg32 &&
-				format != SurfaceFormat.Rgba64 &&
-				format != SurfaceFormat.Single &&
-				format != SurfaceFormat.Vector2 &&
-				format != SurfaceFormat.Vector4 &&
-				format != SurfaceFormat.HalfSingle &&
-				format != SurfaceFormat.HalfVector2 &&
-				format != SurfaceFormat.HalfVector4 &&
-				format != SurfaceFormat.HdrBlendable	)
+			if (this is IRenderTarget)
 			{
-				Format = SurfaceFormat.Color;
+				if (format == SurfaceFormat.ColorSrgbEXT)
+				{
+					if (FNA3D.FNA3D_SupportsSRGBRenderTargets(GraphicsDevice.GLDevice) == 0)
+					{
+						// Renderable but not on this device
+						Format = SurfaceFormat.Color;
+					}
+					else
+					{
+						Format = format;
+					}
+				}
+				else if (	format != SurfaceFormat.Color &&
+						format != SurfaceFormat.Rgba1010102 &&
+						format != SurfaceFormat.Rg32 &&
+						format != SurfaceFormat.Rgba64 &&
+						format != SurfaceFormat.Single &&
+						format != SurfaceFormat.Vector2 &&
+						format != SurfaceFormat.Vector4 &&
+						format != SurfaceFormat.HalfSingle &&
+						format != SurfaceFormat.HalfVector2 &&
+						format != SurfaceFormat.HalfVector4 &&
+						format != SurfaceFormat.HdrBlendable	)
+				{
+					// Not a renderable format period
+					Format = SurfaceFormat.Color;
+				}
+				else
+				{
+					Format = format;
+				}
 			}
 			else
 			{

--- a/src/Graphics/TextureCube.cs
+++ b/src/Graphics/TextureCube.cs
@@ -302,16 +302,14 @@ namespace Microsoft.Xna.Framework.Graphics
 			using (BinaryReader reader = new BinaryReader(stream))
 			{
 
-			int width, height, levels, levelSize, blockSize;
+			int width, height, levels;
 			SurfaceFormat format;
 			Texture.ParseDDS(
 				reader,
 				out format,
 				out width,
 				out height,
-				out levels,
-				out levelSize,
-				out blockSize
+				out levels
 			);
 
 			// Allocate/Load texture
@@ -328,9 +326,13 @@ namespace Microsoft.Xna.Framework.Graphics
 			{
 				for (int face = 0; face < 6; face += 1)
 				{
-					int mipLevelSize = levelSize;
 					for (int i = 0; i < levels; i += 1)
 					{
+						int mipLevelSize = Texture.CalculateDDSLevelSize(
+							width >> i,
+							width >> i,
+							format
+						);
 						result.SetData(
 							(CubeMapFace) face,
 							i,
@@ -343,10 +345,6 @@ namespace Microsoft.Xna.Framework.Graphics
 							mipLevelSize,
 							SeekOrigin.Current
 						);
-						mipLevelSize = Math.Max(
-							mipLevelSize >> 2,
-							blockSize
-						);
 					}
 				}
 			}
@@ -354,10 +352,13 @@ namespace Microsoft.Xna.Framework.Graphics
 			{
 				for (int face = 0; face < 6; face += 1)
 				{
-					int mipLevelSize = levelSize;
 					for (int i = 0; i < levels; i += 1)
 					{
-						tex = reader.ReadBytes(mipLevelSize);
+						tex = reader.ReadBytes(Texture.CalculateDDSLevelSize(
+							width >> i,
+							width >> i,
+							format
+						));
 						result.SetData(
 							(CubeMapFace) face,
 							i,
@@ -365,10 +366,6 @@ namespace Microsoft.Xna.Framework.Graphics
 							tex,
 							0,
 							tex.Length
-						);
-						mipLevelSize = Math.Max(
-							mipLevelSize >> 2,
-							blockSize
 						);
 					}
 				}

--- a/src/Graphics/Vertices/BufferUsage.cs
+++ b/src/Graphics/Vertices/BufferUsage.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Vertices/DynamicIndexBuffer.cs
+++ b/src/Graphics/Vertices/DynamicIndexBuffer.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Vertices/DynamicVertexBuffer.cs
+++ b/src/Graphics/Vertices/DynamicVertexBuffer.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Vertices/IVertexType.cs
+++ b/src/Graphics/Vertices/IVertexType.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Vertices/IndexBuffer.cs
+++ b/src/Graphics/Vertices/IndexBuffer.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Vertices/IndexElementSize.cs
+++ b/src/Graphics/Vertices/IndexElementSize.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Vertices/VertexBuffer.cs
+++ b/src/Graphics/Vertices/VertexBuffer.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Vertices/VertexBufferBinding.cs
+++ b/src/Graphics/Vertices/VertexBufferBinding.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Vertices/VertexDeclaration.cs
+++ b/src/Graphics/Vertices/VertexDeclaration.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Vertices/VertexDeclarationCache.cs
+++ b/src/Graphics/Vertices/VertexDeclarationCache.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Vertices/VertexElement.cs
+++ b/src/Graphics/Vertices/VertexElement.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Vertices/VertexElementFormat.cs
+++ b/src/Graphics/Vertices/VertexElementFormat.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Vertices/VertexElementUsage.cs
+++ b/src/Graphics/Vertices/VertexElementUsage.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Vertices/VertexPositionColor.cs
+++ b/src/Graphics/Vertices/VertexPositionColor.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Vertices/VertexPositionColorTexture.cs
+++ b/src/Graphics/Vertices/VertexPositionColorTexture.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Vertices/VertexPositionNormalTexture.cs
+++ b/src/Graphics/Vertices/VertexPositionNormalTexture.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Vertices/VertexPositionTexture.cs
+++ b/src/Graphics/Vertices/VertexPositionTexture.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Viewport.cs
+++ b/src/Graphics/Viewport.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/X360TexUtil.cs
+++ b/src/Graphics/X360TexUtil.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/GraphicsDeviceInformation.cs
+++ b/src/GraphicsDeviceInformation.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/GraphicsDeviceManager.cs
+++ b/src/GraphicsDeviceManager.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/GraphicsDeviceManager.cs
+++ b/src/GraphicsDeviceManager.cs
@@ -405,6 +405,7 @@ namespace Microsoft.Xna.Framework
 
 			FNAPlatform.ScaleForWindow(
 				window.Handle,
+				true,
 				ref resizedBackBufferWidth,
 				ref resizedBackBufferHeight
 			);

--- a/src/GraphicsDeviceManager.cs
+++ b/src/GraphicsDeviceManager.cs
@@ -239,6 +239,8 @@ namespace Microsoft.Xna.Framework
 		{
 			if (!disposed)
 			{
+				game.Services.RemoveService(typeof(IGraphicsDeviceManager));
+				game.Services.RemoveService(typeof(IGraphicsDeviceService));
 				if (disposing)
 				{
 					if (graphicsDevice != null)

--- a/src/GraphicsDeviceManager.cs
+++ b/src/GraphicsDeviceManager.cs
@@ -397,14 +397,18 @@ namespace Microsoft.Xna.Framework
 
 		private void INTERNAL_OnClientSizeChanged(object sender, EventArgs e)
 		{
-			Rectangle size = (sender as GameWindow).ClientBounds;
+			GameWindow window = (sender as GameWindow);
+
+			Rectangle size = window.ClientBounds;
 			resizedBackBufferWidth = size.Width;
 			resizedBackBufferHeight = size.Height;
-			if (Environment.GetEnvironmentVariable("FNA_GRAPHICS_ENABLE_HIGHDPI") == "1")
-			{
-				resizedBackBufferWidth *= 2;
-				resizedBackBufferHeight *= 2;
-			}
+
+			FNAPlatform.ScaleForWindow(
+				window.Handle,
+				ref resizedBackBufferWidth,
+				ref resizedBackBufferHeight
+			);
+
 			useResizedBackBuffer = true;
 			ApplyChanges();
 		}

--- a/src/IDrawable.cs
+++ b/src/IDrawable.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/IGameComponent.cs
+++ b/src/IGameComponent.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/IGraphicsDeviceManager.cs
+++ b/src/IGraphicsDeviceManager.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/IUpdateable.cs
+++ b/src/IUpdateable.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Input/ButtonState.cs
+++ b/src/Input/ButtonState.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Input/Buttons.cs
+++ b/src/Input/Buttons.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Input/GamePad.cs
+++ b/src/Input/GamePad.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Input/GamePadButtons.cs
+++ b/src/Input/GamePadButtons.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Input/GamePadCapabilities.cs
+++ b/src/Input/GamePadCapabilities.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Input/GamePadDPad.cs
+++ b/src/Input/GamePadDPad.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Input/GamePadDeadZone.cs
+++ b/src/Input/GamePadDeadZone.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Input/GamePadState.cs
+++ b/src/Input/GamePadState.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Input/GamePadThumbSticks.cs
+++ b/src/Input/GamePadThumbSticks.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Input/GamePadTriggers.cs
+++ b/src/Input/GamePadTriggers.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Input/GamePadType.cs
+++ b/src/Input/GamePadType.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Input/KeyState.cs
+++ b/src/Input/KeyState.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Input/Keyboard.cs
+++ b/src/Input/Keyboard.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Input/KeyboardState.cs
+++ b/src/Input/KeyboardState.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Input/Keys.cs
+++ b/src/Input/Keys.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Input/Mouse.cs
+++ b/src/Input/Mouse.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Input/MouseState.cs
+++ b/src/Input/MouseState.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Input/Touch/GestureDetector.cs
+++ b/src/Input/Touch/GestureDetector.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Input/Touch/GestureSample.cs
+++ b/src/Input/Touch/GestureSample.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Input/Touch/GestureType.cs
+++ b/src/Input/Touch/GestureType.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Input/Touch/TouchCollection.cs
+++ b/src/Input/Touch/TouchCollection.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Input/Touch/TouchLocation.cs
+++ b/src/Input/Touch/TouchLocation.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Input/Touch/TouchLocationState.cs
+++ b/src/Input/Touch/TouchLocationState.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Input/Touch/TouchPanel.cs
+++ b/src/Input/Touch/TouchPanel.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Input/Touch/TouchPanelCapabilities.cs
+++ b/src/Input/Touch/TouchPanelCapabilities.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Interop/FNA3D.cs
+++ b/src/Interop/FNA3D.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Interop/FNA3D.cs
+++ b/src/Interop/FNA3D.cs
@@ -817,6 +817,9 @@ namespace Microsoft.Xna.Framework.Graphics
 		public static extern byte FNA3D_SupportsNoOverwrite(IntPtr device);
 
 		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+		public static extern byte FNA3D_SupportsSRGBRenderTargets(IntPtr device);
+
+		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
 		public static extern void FNA3D_GetMaxTextureSlots(
 			IntPtr device,
 			out int textures,

--- a/src/Interop/FNA3D.cs
+++ b/src/Interop/FNA3D.cs
@@ -841,10 +841,19 @@ namespace Microsoft.Xna.Framework.Graphics
 		#region Debugging
 
 		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
-		public static extern void FNA3D_SetStringMarker(
+		private static extern unsafe void FNA3D_SetStringMarker(
 			IntPtr device,
-			[MarshalAs(UnmanagedType.LPStr)] string text
+			byte* text
 		);
+
+		public static unsafe void FNA3D_SetStringMarker(
+			IntPtr device,
+			string text
+		) {
+			byte* utf8Text = SDL2.SDL.Utf8EncodeHeap(text);
+			FNA3D_SetStringMarker(device, utf8Text);
+			Marshal.FreeHGlobal((IntPtr) utf8Text);
+		}
 
 		#endregion
 

--- a/src/Interop/FNA3D.cs
+++ b/src/Interop/FNA3D.cs
@@ -809,6 +809,9 @@ namespace Microsoft.Xna.Framework.Graphics
 		public static extern byte FNA3D_SupportsS3TC(IntPtr device);
 
 		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+		public static extern byte FNA3D_SupportsBC7(IntPtr device);
+
+		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
 		public static extern byte FNA3D_SupportsHardwareInstancing(
 			IntPtr device
 		);

--- a/src/Interop/Theorafile.cs
+++ b/src/Interop/Theorafile.cs
@@ -199,6 +199,9 @@ public static class Theorafile
 	public static extern int tf_setaudiotrack(IntPtr file, int track);
 
 	[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+	public static extern int tf_setvideotrack(IntPtr file, int track);
+
+	[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
 	public static extern int tf_eos(IntPtr file);
 
 	[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]

--- a/src/LaunchParameters.cs
+++ b/src/LaunchParameters.cs
@@ -2,7 +2,7 @@
 /*
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/MathHelper.cs
+++ b/src/MathHelper.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Matrix.cs
+++ b/src/Matrix.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Media/MediaPlayer.cs
+++ b/src/Media/MediaPlayer.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Media/MediaQueue.cs
+++ b/src/Media/MediaQueue.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Media/MediaState.cs
+++ b/src/Media/MediaState.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Media/Song.cs
+++ b/src/Media/Song.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Media/SongCollection.cs
+++ b/src/Media/SongCollection.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Media/VideoSoundtrackType.cs
+++ b/src/Media/VideoSoundtrackType.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Media/VisualizationData.cs
+++ b/src/Media/VisualizationData.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Media/Xiph/Video.cs
+++ b/src/Media/Xiph/Video.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Media/Xiph/Video.cs
+++ b/src/Media/Xiph/Video.cs
@@ -173,6 +173,14 @@ namespace Microsoft.Xna.Framework.Media
 			}
 		}
 
+		public void SetVideoTrackEXT(int track)
+		{
+			if (theora != IntPtr.Zero)
+			{
+				Theorafile.tf_setvideotrack(theora, track);
+			}
+		}
+
 		#endregion
 
 		#region Destructor

--- a/src/Media/Xiph/VideoPlayer.cs
+++ b/src/Media/Xiph/VideoPlayer.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/NamespaceDocs.cs
+++ b/src/NamespaceDocs.cs
@@ -1,5 +1,5 @@
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Plane.cs
+++ b/src/Plane.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/PlaneIntersectionType.cs
+++ b/src/PlaneIntersectionType.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/PlayerIndex.cs
+++ b/src/PlayerIndex.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Point.cs
+++ b/src/Point.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/PreparingDeviceSettingsEventArgs.cs
+++ b/src/PreparingDeviceSettingsEventArgs.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Quaternion.cs
+++ b/src/Quaternion.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Ray.cs
+++ b/src/Ray.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Rectangle.cs
+++ b/src/Rectangle.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Storage/StorageContainer.cs
+++ b/src/Storage/StorageContainer.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Storage/StorageDevice.cs
+++ b/src/Storage/StorageDevice.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Storage/StorageDeviceNotConnectedException.cs
+++ b/src/Storage/StorageDeviceNotConnectedException.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/TitleContainer.cs
+++ b/src/TitleContainer.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/TitleLocation.cs
+++ b/src/TitleLocation.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Utilities/FNADllMap.cs
+++ b/src/Utilities/FNADllMap.cs
@@ -82,6 +82,13 @@ namespace Microsoft.Xna.Framework
 		[ModuleInitializer]
 		public static void Init()
 		{
+			// Ignore NativeAOT platforms since they don't perform dynamic loading.
+			// FIXME: Is the iOS check needed?
+			if (!RuntimeFeature.IsDynamicCodeSupported && !OperatingSystem.IsIOS())
+			{
+				return;
+			}
+
 			// Get the platform and architecture
 			string os = GetPlatformName();
 			string cpu = RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant();

--- a/src/Utilities/FNADllMap.cs
+++ b/src/Utilities/FNADllMap.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Utilities/FNAInternalExtensions.cs
+++ b/src/Utilities/FNAInternalExtensions.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Vector2.cs
+++ b/src/Vector2.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Vector3.cs
+++ b/src/Vector3.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Vector4.cs
+++ b/src/Vector4.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2021 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.


### PR DESCRIPTION
- Sync FNA3D codebase to FNA(deprecates Metal as FNA)
- Updated fnalibs binaries
- Fix iOS/tvOS target by referencing `FNA.NET.MoltenVK` package.
- Sync(cherry-pick) commits from FNA